### PR TITLE
Remove DRS Topic Logic

### DIFF
--- a/env-template.txt
+++ b/env-template.txt
@@ -9,8 +9,7 @@ DRS_MQ_HOST=b-20382e88-7651-49e3-b904-76b421818e4f-1.mq.us-east-1.amazonaws.com
 DRS_MQ_PORT=61614
 DRS_MQ_USER=XXX
 DRS_MQ_PASSWORD=XXX
-#DRS_TOPIC_NAME=/topic/Consumer.dts-dev.VirtualTopic.DRS_OBJECT_UPDATED
-DRS_TOPIC_NAME=/topic/dts-dev-DRS_OBJECT_UPDATED
+DRS_QUEUE_CONSUME_NAME=/queue/mock-drs-ingest-complete
 DRS_QUEUE_PUBLISH_NAME=/queue/mock-drs-ingest-trigger
 
 

--- a/mqutils/mqutils.py
+++ b/mqutils/mqutils.py
@@ -5,13 +5,14 @@ loglevel=os.getenv('LOGLEVEL', 'WARNING')
 logging.basicConfig(filename=logfile, level=loglevel)
 
 class ConnectionParams:
-    def __init__(self, conn, queue, host, port, user, password):
+    def __init__(self, conn, queue, host, port, user, password, ack="client-individual"):
         self.conn = conn
         self.queue = queue
         self.host = host
         self.port = port
         self.user = user
         self.password = password
+        self.ack = ack
         
 def get_process_mq_connection(queue=None):
     logging.debug("************************ MQUTILS - GET_PROCESS_MQ_CONNECTION *******************************")
@@ -33,22 +34,27 @@ def get_process_mq_connection(queue=None):
         raise(e)
     return connection_params
 
-def notify_ingest_status_process_message(queue=None):
+def notify_ingest_status_process_message(package_id, status, urn, queue=None):
     '''Creates a json message to notify the DIMS that the drs ingest has finished an ingest attempt'''
     logging.debug("************************ MQUTILS - CREATE_PROCESS_MESSAGE *******************************")
     message = "No message"
     try:
-        #Add more details that will be needed from the load report.
-        msg_json = {
-            "package_id": "12345",
-            "application_name": "Dataverse",
-            "batch_ingest_status": "success",
-            "message": "Some Notes"
-        }
         if (queue is None):
             process_queue = os.getenv('PROCESS_QUEUE_PUBLISH_NAME')
         else:
             process_queue = queue
+        
+        msg_json = {
+            "package_id": package_id,
+            "application_name": "Dataverse",
+            "batch_ingest_status": status,
+            "drs_uri": urn,
+            "admin_metadata": { 
+                "original_queue": process_queue,
+                "retry_count": 0 
+            }
+
+        }
                 
         logging.debug("msg json:")
         logging.debug(msg_json)
@@ -71,42 +77,37 @@ def get_drs_mq_connection(queue=None):
         user = os.getenv('DRS_MQ_USER')
         password = os.getenv('DRS_MQ_PASSWORD')
         if (queue is None):
-            drs_queue = os.getenv('DRS_TOPIC_NAME')
+            drs_queue = os.getenv('DRS_QUEUE_CONSUME_NAME')
         else:
             drs_queue = queue
         logging.debug("************************ QUEUE: {} *******************************".format(drs_queue))
     
         conn = stomp.Connection([(host, port)], heartbeats=(40000, 40000), keepalive=True)
         conn.set_ssl([(host, port)])
-        connection_params = ConnectionParams(conn, drs_queue, host, port, user, password)
+        connection_params = ConnectionParams(conn, drs_queue, host, port, user, password, "auto")
         conn.connect(user, password, wait=True)
     except Exception as e:
         logging.error(e)
         raise(e)
     return connection_params
 
-def notify_mock_drs_trigger_message(queue=None):
+def notify_mock_drs_trigger_message(package_id):
     '''Creates a mock message that indicates that the drs'''
     logging.debug("************************ MQUTILS - CREATE_PROCESS_MESSAGE *******************************")
     message = "No message"
     try:
         #Add more details that will be needed from the load report.
         msg_json = {
-            "package_id": "12345",
-            "application_name": "Dataverse",
-            "batch_ingest_status": "success",
-            "message": "Some Notes"
+            "package_id": package_id,
+            "application_name": "Dataverse"
         }
-        if (queue is None):
-            drs_queue = os.getenv('DRS_QUEUE_PUBLISH_NAME')
-        else:
-            drs_queue = queue
-                
+        queue = os.getenv('DRS_QUEUE_PUBLISH_NAME')
+      
         logging.debug("msg json:")
         logging.debug(msg_json)
         message = json.dumps(msg_json)
-        connection_params = get_drs_mq_connection(drs_queue)
-        connection_params.conn.send(drs_queue, message, headers = {"persistent": "true"})
+        connection_params = get_drs_mq_connection(queue)
+        connection_params.conn.send(queue, message, headers = {"persistent": "true"})
         logging.debug("MESSAGE TO QUEUE create_initial_queue_message")
         logging.debug(message)
     except Exception as e:

--- a/mqutils/tests/integration/test_mqlistener.py
+++ b/mqutils/tests/integration/test_mqlistener.py
@@ -5,33 +5,8 @@ import mqlistener as mqlistener
 
 logging.basicConfig(format='%(message)s')
 
-_process_queue = "/queue/dims-data-ready"
-_drs_queue = "/topic/dvn-dev-DRS_OBJECT_UPDATED"
+_process_queue = "/queue/dims-data-ready-testing"
 
-def test_drs_listener():
-    '''Tests to see if the listener picks up a topic from the queue'''
-    mqlistenerobject = mqlistener.get_drsmqlistener(_drs_queue)
-    
-    conn = mqlistenerobject.get_connection()
-    conn.set_listener('', mqlistenerobject)
-    mqlistener.subscribe_to_listener(mqlistenerobject.connection_params)
-    
-    message = notify_drs_message()
-    messagedict = json.loads(message)
-    
-    counter = 0
-    #Try for 30 seconds then fail
-    while mqlistenerobject.get_message_data() is None:
-        time.sleep(2)
-        counter = counter+2
-        if not conn.is_connected():
-            mqlistener.subscribe_to_listener(mqlistenerobject.connection_params)
-        if counter >= 30:
-            assert False, "test_drs_listener: could not find anything on the queue after 30 seconds"
-        
-    assert mqlistenerobject.get_message_data() is not None
-    assert type(mqlistenerobject.get_message_data()) is dict
-    assert mqlistenerobject.get_message_data() == messagedict
     
 def test_process_listener():
     message = notify_data_ready_process_message()

--- a/mqutils/tests/integration/test_mqutils.py
+++ b/mqutils/tests/integration/test_mqutils.py
@@ -12,7 +12,7 @@ def test_get_process_mq_connection():
 def test_notification():
     '''Sends a status message to the process queue and verifies that it made it'''
     #Send the message
-    message = mqutils.notify_process_message("/queue/drs-ingest-status-testing")
+    message = mqutils.notify_ingest_status_process_message("12345", "success", "https://nrs-dev.lts.harvard.edu/URN-3:HUL.TEST:101113553", "/queue/drs-ingest-status-testing")
     assert type(message) is str
     messagedict = json.loads(message)
     


### PR DESCRIPTION
**Removes the DRS topic logic and relies on mock services**
* * *

**GitHub Issue**: https://github.com/harvard-lts/HDC/issues/181

# What does this Pull Request do?
Removes the former logic needed for the PR

# How should this be tested?

1. Clone the repo
2. Checkout the branch HDC-181
3. Copy the env-template.txt to .env
4. Get the credentials from LPE Shared-HDC/Dev/QA ims ActiveMQ (transfer and process) for ims-process-dev
5. Add the credentials from step 4 to the .env for the PROCESS queueing and DRS 
6. Set .env variables:
```
DRS_QUEUE_CONSUME_NAME=/queue/mock-drs-ingest-complete-local
DRS_QUEUE_PUBLISH_NAME=/queue/mock-drs-ingest-trigger-local
PROCESS_QUEUE_CONSUME_NAME=/queue/dims-data-ready-mock-local
PROCESS_QUEUE_PUBLISH_NAME=/queue/drs-ingest-status-local
```
8. Start up the docker container: `docker-compose -f docker-compose-local.yml up -d --build --force-recreate`
9. Exec into the container: `docker exec -it mqutils bash`
10. Run the command `pytest`

# Test coverage
Yes/No: Are changes in this pull-request covered by:
- unit tests? yes
- integration tests? yes


