### PR TITLE
Handling of load reports and failed batches

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -4,6 +4,7 @@ import werkzeug
 from healthcheck import HealthCheck, EnvironmentDump
 import mqresources.mqutils as mqutils
 import load_report_service.load_report_service as load_report_service
+from load_report_service.load_report_exception import LoadReportException
 
 '''This class is currently entirely for the purpose of providing
 a healthcheck '''
@@ -53,7 +54,15 @@ def create_app():
         args = request.args
         if ("filename" not in args):
             return 'Missing filename argument!', 400
-        load_report_service.handle_load_report(args['filename'])
+        dryrun = False
+        if ("dryrun" in args):
+            dryrun = True
+        try:
+            load_report_service.handle_load_report(args['filename'], dryrun)
+        except LoadReportException as lre:
+            return "Handling of load report failed: {}".format(str(lre)), 400
+        except Exception as e: 
+            return "Handling of load report failed: {}".format(str(e)), 500
         return "ok", 200
 
     @app.route('/failedBatch', endpoint="failedBatch")
@@ -62,6 +71,15 @@ def create_app():
         args = request.args
         if ("batchName" not in args):
             return 'Missing batchName argument!', 400
-        load_report_service.handle_load_report(args['batchName'])
+        dryrun = False
+        if ("dryrun" in args):
+            dryrun = True
+        
+        try:
+            load_report_service.handle_failed_batch(args['batchName'], dryrun)
+        except LoadReportException as lre:
+            return "Handling of failed batch returned an error: {}".format(str(lre)), 400
+        except Exception as e: 
+            return "Handling of failed batch returned an error: {}".format(str(e)), 500
         return "ok", 200
     return app

--- a/app/load_report_service/load_report.py
+++ b/app/load_report_service/load_report.py
@@ -1,0 +1,82 @@
+#!/usr/bin/env python3
+
+import sys, os.path, logging
+from load_report_service.load_report_exception import LoadReportException
+
+'''
+Parses a load report and manipulates some of the contents
+'''
+class LoadReport:
+    
+    #Constants
+    BATCH_NAME_LINE_PREFIX = "Batch name: ";
+    BATCH_DIRECTORY_LINE_PREFIX = "Batch directory name: ";
+    DRS_FILELIST_SECTION_LINE_PREFIX = "OBJ-ID"
+        
+    #The column location of the fields in the report (drs_).
+    DRS_OBJECT_ID_INDEX = 0
+    DRS_OBJ_DELIVERABLE_URI_INDEX = 1
+    DRS_OBJECT_URN_INDEX = 2
+    DRS_DEPOSITOR_NAME_INDEX = 3
+    DRS_OBJECT_OWNER_SUPPLIED_NAME_INDEX = 4
+    DRS_BILLING_INDEX = 5
+    DRS_OWNER_INDEX = 6
+    DRS_OBJECT_TYPE_INDEX = 7
+    DRS_OBJECT_ROLES_INDEX = 8
+    DRS_FILE_ID_INDEX = 9
+    DRS_FILE_URN_INDEX= 10
+    DRS_FILE_FORMAT_INDEX = 11
+    DRS_FILE_SIZE_INDEX = 12
+    DRS_FILE_OWNER_SUPPLIED_NAME_INDEX = 13
+    DRS_FILE_ORIGINAL_PATH_INDEX = 14
+    
+    """ Initiator function """
+    def __init__(self, load_report_path):   
+        self.load_report_path = load_report_path
+    
+    
+    #Parse the report and extract the OSN URN
+    # and file information.
+    # 
+    #There are 3 different sections in the loader report:
+    # 1. batch summary
+    # 2. file list
+    # 3. relationship list
+    # 
+    #This method relies on knowing which of the 3 sections it is in.
+    # 
+    def get_obj_urn(self):
+
+        file = None
+        
+        try: 
+            file = open(self.load_report_path, "r")
+        except FileNotFoundError:
+            logging.warning('Load Report Filepath does not exist: {}'.format(self.load_report_path))
+            raise LoadReportException("ERROR OPENING LOAD REPORT", 'Load Report Filepath does not exist: {}'.format(self.load_report_path))
+
+        if file is not None:
+            
+            lines = file.readlines()
+            in_file_section = False
+            
+            for line in lines:
+                if in_file_section:
+                    fields = line.rstrip('\n').split("\t")
+                    if len(fields) == 15 and fields[self.DRS_FILE_OWNER_SUPPLIED_NAME_INDEX] != 'null':
+                        #Update the database
+                        try:
+                            #All files will have the same object urn
+                            obj_urn = fields[self.DRS_OBJECT_URN_INDEX]
+                            return obj_urn
+                        except Exception as why:
+                            raise LoadReportException("Error in Load Report Parsing", "An unexpected error occurred while parsing the load report "+self.load_report_path + "\n" + str(why))
+                elif line.startswith(self.DRS_FILELIST_SECTION_LINE_PREFIX):
+                    in_file_section = True
+                
+            
+            file.close()
+        else:
+            raise LoadReportException("Error in Load Report Parsing", "Could not open load report: " + self.load_report_path) 
+
+        return None

--- a/app/load_report_service/load_report.py
+++ b/app/load_report_service/load_report.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 
-import sys, os.path, logging
+import logging
 from load_report_service.load_report_exception import LoadReportException
 
 '''

--- a/app/load_report_service/load_report_exception.py
+++ b/app/load_report_service/load_report_exception.py
@@ -1,0 +1,2 @@
+class LoadReportException(Exception):
+    pass

--- a/app/load_report_service/load_report_service.py
+++ b/app/load_report_service/load_report_service.py
@@ -1,11 +1,79 @@
-import os, os.path, logging
+import os, os.path, logging, shutil
+from load_report_service.load_report import LoadReport
+from load_report_service.load_report_exception import LoadReportException
+import mqresources.mqutils as mqutils
 
 logfile=os.getenv('LOGFILE_PATH', 'drs_translation_service')
 loglevel=os.getenv('LOGLEVEL', 'WARNING')
-logging.basicConfig(filename=logfile, level=loglevel)
+logging.basicConfig(filename=logfile, level=loglevel, format="%(asctime)s:%(levelname)s:%(message)s")
 
-def handle_load_report(package_name):
-    #TODO
-    pass
+load_report_dir = os.getenv("LOADREPORT_PATH")
+dropbox_dir = os.getenv("DROPBOX_PATH")
+
+def handle_load_report(load_report_name, dry_run = False):
+    #Strip off the LOADREPORT_ to get the batch name
+    if (not load_report_name.startswith("LOADREPORT_")):
+        raise LoadReportException("ERROR Expected load report name, {}, to begin with LOADREPORT_".format(load_report_name))
+    
+    batch_name = load_report_name[11:-4]
+    load_report_path = os.path.join(load_report_dir, batch_name, load_report_name)
+   
+    # Parse the LRs (attempt even if none were brought from the dropbox)
+    obj_osn = _parse_load_report(load_report_path)
+    if not dry_run:
+        #Delete the LR from the dropbox
+        _delete_load_report_from_dropbox(os.path.join(load_report_dir, batch_name))
+        #Delete the batch
+        _delete_batch_from_dropbox(os.path.join(dropbox_dir, batch_name))  
+        
+    if (obj_osn is None):
+        raise LoadReportException("ERROR Object OSN could not be found in load report, {}.".format(load_report_path))
+    
+    nrs_prefix = os.getenv("NRS_PREFIX")    
+    urn = os.path.join(nrs_prefix, obj_osn)
+    mqutils.notify_ingest_status_process_message(batch_name, "success", urn)
+    return urn
+    
+
+def handle_failed_batch(batch_name, dry_run = False):
+    #Send failed notification
+    mqutils.notify_ingest_status_process_message(batch_name, "failed")
+    #Delete batch from dropbox
+    if not dry_run:
+        _delete_batch_from_dropbox(os.path.join(dropbox_dir, batch_name)) 
+    return batch_name
+    
+def _delete_load_report_from_dropbox(load_report_path):
+    '''
+    Deletes the load report from the dropbox.
+    If an error occurs in the deletion, the error is written to the log but no exception is thrown
+    since it will try again next time
+    '''
+    try:
+        shutils.rmtree(load_report_path)
+    except Exception:
+        logging.exception("Error in deleting load report {} from the dropbox.".format(load_report_path))
+        raise LoadReportException("ERROR Deleting Load Report from dropbox", "Error in deleting load report {} from the dropbox.".format(load_report_path)) 
+
+def _delete_batch_from_dropbox(batch_path):
+    '''
+    Deletes the batch from the dropbox.
+    If an error occurs in the deletion, the error is written to the log but no exception is thrown
+    '''
+    try:
+        shutils.rmtree(batch_path)
+    except Exception:
+        logging.exception("Error in deleting batch {} from the dropbox".format(batch_path))
+        raise LoadReportException("ERROR Deleting Batch from Dropbox", "Error in deleting batch {} from the dropbox".format(batch_path)) 
+      
+
+    
+def _parse_load_report(local_load_report_path):
+    '''
+    Reads and parses the values of the load report and returns the obj_urn. 
+    '''
+    load_report = LoadReport(local_load_report_path)
+    return load_report.get_obj_urn()
+                    
     
     

--- a/app/load_report_service/load_report_service.py
+++ b/app/load_report_service/load_report_service.py
@@ -50,7 +50,7 @@ def _delete_load_report_from_dropbox(load_report_path):
     since it will try again next time
     '''
     try:
-        shutils.rmtree(load_report_path)
+        shutil.rmtree(load_report_path)
     except Exception:
         logging.exception("Error in deleting load report {} from the dropbox.".format(load_report_path))
         raise LoadReportException("ERROR Deleting Load Report from dropbox", "Error in deleting load report {} from the dropbox.".format(load_report_path)) 
@@ -61,7 +61,7 @@ def _delete_batch_from_dropbox(batch_path):
     If an error occurs in the deletion, the error is written to the log but no exception is thrown
     '''
     try:
-        shutils.rmtree(batch_path)
+        shutil.rmtree(batch_path)
     except Exception:
         logging.exception("Error in deleting batch {} from the dropbox".format(batch_path))
         raise LoadReportException("ERROR Deleting Batch from Dropbox", "Error in deleting batch {} from the dropbox".format(batch_path)) 

--- a/app/mqresources/mqlistener.py
+++ b/app/mqresources/mqlistener.py
@@ -12,7 +12,7 @@ _max_attempts = 1000
 
 logfile=os.getenv('LOGFILE_PATH', 'drs_translation_service')
 loglevel=os.getenv('LOGLEVEL', 'WARNING')
-logging.basicConfig(filename=logfile, level=loglevel)
+logging.basicConfig(filename=logfile, level=loglevel, format="%(asctime)s:%(levelname)s:%(message)s")
 
 def subscribe_to_listener(connection_params):
     logging.debug("************************ MQUTILS MQLISTENER - CONNECT_AND_SUBSCRIBE *******************************")

--- a/app/mqresources/mqutils.py
+++ b/app/mqresources/mqutils.py
@@ -2,7 +2,7 @@ import os, json, stomp, logging, time
 
 logfile=os.getenv('LOGFILE_PATH', 'drs_translation_service')
 loglevel=os.getenv('LOGLEVEL', 'WARNING')
-logging.basicConfig(filename=logfile, level=loglevel)
+logging.basicConfig(filename=logfile, level=loglevel, format="%(asctime)s:%(levelname)s:%(message)s")
 
 class ConnectionParams:
     def __init__(self, conn, queue, host, port, user, password, ack="client-individual"):

--- a/app/translation_service/translation_service.py
+++ b/app/translation_service/translation_service.py
@@ -1,5 +1,5 @@
 import os, os.path, logging
-import translate_data_structure_service 
+import translation_service.translate_data_structure_service as translate_data_structure_service
 
 logfile=os.getenv('LOGFILE_PATH', 'drs_translation_service')
 loglevel=os.getenv('LOGLEVEL', 'WARNING')

--- a/docker-compose-local.yml
+++ b/docker-compose-local.yml
@@ -17,11 +17,5 @@ services:
       - './logs:/home/appuser/logs'
     env_file:
       - '.env'
-    # Join this service to a custom docker network
-    networks:
-      - drsts-net
     ports:
       - "10581:8443"
-networks:
-  drsts-net:
-    name: "drsts-net"

--- a/env-template.txt
+++ b/env-template.txt
@@ -9,6 +9,11 @@ PYTHONPATH=/home/appuser/app
 #Default to one hour
 MESSAGE_EXPIRATION_MS=60000
 
+NRS_PREFIX=https://nrs-dev.harvard.edu
+
+DROPBOX_PATH=XXX
+LOADREPORT_PATH=XXX
+
 DRS_MQ_HOST=b-20382e88-7651-49e3-b904-76b421818e4f-1.mq.us-east-1.amazonaws.com
 DRS_MQ_PORT=61614
 DRS_MQ_USER=XXX

--- a/tests/data/sampleloadreport/LOADREPORT_sample.txt
+++ b/tests/data/sampleloadreport/LOADREPORT_sample.txt
@@ -1,0 +1,24 @@
+Batch Summary:
+-------------------------------------------------------------------------
+Batch directory name: sample
+Batch name: HUL.TEST_sample
+Depositor: Crema, Valdeva
+Batch id: 71001
+Owner(s): HUL.TEST
+Batch drop off time: Wed Apr 13 19:59:47 UTC 2022
+Time waiting to start load: 0 hours, 0 minutes, 14 seconds
+Loading start time: Wed Apr 13 20:00:01 UTC 2022
+Loading end time: Wed Apr 13 20:00:09 UTC 2022
+Total load time: 0 hours, 0 minutes, 8 seconds
+Number of objects deposited: 1
+Number of files deposited: 2
+Batch size: 289,515 bytes / 282.729 kilobytes / 0.276 megabytes
+Number of objects per object type:
+	OPAQUE: 1
+Number of files per format:
+	Office Open XML Document: 1
+	Extensible Markup Language: 1
+-------------------------------------------------------------------------
+OBJ-ID	OBJ-DELIV-URN	OBJ-URN	DEPOSITOR	OBJ-OSN	BILLING	OWNER	OBJ-TYPE	OBJ-ROLES	FILE-ID	FILE-URN	FILE-FORMAT	FILE-SIZE	FILE-OSN	FILE-ORIGPATH	
+400308700		URN-3:HUL.DRS.OBJECT:101113552	Crema, Valdeva	object1	HUL.TEST.BILL_0001	HUL.TEST	OPAQUE	THESIS_SUPPLEMENT	400308701		Extensible Markup Language	11554	null	400308700_mets.xml
+400308700		URN-3:HUL.DRS.OBJECT:101113552	Crema, Valdeva	object1	HUL.TEST.BILL_0001	HUL.TEST	OPAQUE	THESIS_SUPPLEMENT	400308702	URN-3:HUL.TEST:101113553	Office Open XML Document	277961	AmericanUtopia	documentation/AmericanUtopia.docx

--- a/tests/unit/test_api_calls.py
+++ b/tests/unit/test_api_calls.py
@@ -1,20 +1,30 @@
 import requests, sys, os
 sys.path.append('app')
-
-dts_endpoint = os.getenv("DTS_ENDPOINT")
+import unit_test_helper
 
 def test_valid_loadreport_call():
-    response = requests.get("https://localhost:8443/loadreport?filename=abc", verify=False)
+    unit_test_helper.deposit_sample_load_report()
+    response = requests.get("https://localhost:8443/loadreport?filename={}&dryrun=True".format(unit_test_helper.sample_load_report), verify=False)
     assert response.status_code == 200
+    unit_test_helper.cleanup_sample_load_report()
     
 def test_invalid_loadreport_call():
     response = requests.get("https://localhost:8443/loadreport", verify=False)
     assert response.status_code == 400
+    
+def test_invalid_loadreport_no_such_filename_call():
+    response = requests.get("https://localhost:8443/loadreport?filename=abc", verify=False)
+    assert response.status_code == 400
 
 def test_valid_batchfailed_call():
-    response = requests.get("https://localhost:8443/failedBatch?batchName=abc", verify=False)
+    response = requests.get("https://localhost:8443/failedBatch?batchName=sample&dryrun=True", verify=False)
     assert response.status_code == 200
     
 def test_invalid_batchfailed_call():
     response = requests.get("https://localhost:8443/failedBatch", verify=False)
     assert response.status_code == 400
+
+def test_invalid_batchfailed_no_such_batch_call():
+    response = requests.get("https://localhost:8443/failedBatch?batchName=abc", verify=False)
+    assert response.status_code == 400
+        

--- a/tests/unit/test_load_report_service.py
+++ b/tests/unit/test_load_report_service.py
@@ -1,0 +1,21 @@
+import pytest, sys, os.path, shutil
+sys.path.append('app')
+import load_report_service.load_report_service as load_report_service
+import unit_test_helper
+
+nrs_prefix = os.getenv("NRS_PREFIX")
+
+def test_handle_load_report():
+    '''Tests that the obj urn is retrieved properly'''
+    unit_test_helper.deposit_sample_load_report()
+    obj_urn = load_report_service.handle_load_report(unit_test_helper.sample_load_report, True)
+    assert obj_urn.startswith(os.path.join(nrs_prefix, "URN-3"))
+    unit_test_helper.cleanup_sample_load_report()
+            
+def test_handle_failed_batch():
+    '''Tests that the failed batch marker exists'''
+    unit_test_helper.create_sample_failed_batch()
+    batch_name = load_report_service.handle_failed_batch("sample", True)
+    assert batch_name == "sample"
+    unit_test_helper.cleanup_sample_failed_batch()
+            

--- a/tests/unit/unit_test_helper.py
+++ b/tests/unit/unit_test_helper.py
@@ -1,0 +1,35 @@
+import requests, sys, os, shutil
+sys.path.append('app')
+    
+dropbox_path = os.getenv("DROPBOX_PATH")
+sample_load_report="LOADREPORT_sample.txt"
+load_report_path = os.getenv("LOADREPORT_PATH")
+
+def deposit_sample_load_report():
+    '''Creates a sample load report'''
+    sourcepath = os.path.join("/home/appuser/tests/data/sampleloadreport/", sample_load_report)
+    os.makedirs(os.path.join(load_report_path, "sample"), exist_ok=True)
+    try:
+        shutil.copyfile(sourcepath, os.path.join(load_report_path, "sample", sample_load_report))
+    except OSError as e:
+        print("Error during copy: %s : %s" % (os.path.join(load_report_path, "sample", sample_load_report), e.strerror))
+        
+def cleanup_sample_load_report():
+    '''Removes the sample load report'''
+    try:
+        shutil.rmtree(os.path.join(load_report_path, "sample"))
+    except OSError as e:
+        print("Error during cleanup: %s : %s" % (os.path.join(load_report_path, "sample", sample_load_report), e.strerror))
+        
+def create_sample_failed_batch():
+    '''Creates a sample failed batch'''
+    failed_batch_file = os.path.join(dropbox_path, "sample", "batch.xml.failed")
+    os.makedirs(os.path.join(dropbox_path, "sample"), exist_ok=True)
+    open(failed_batch_file, 'a').close()
+
+def cleanup_sample_failed_batch():
+    '''Removes the newly failed batch'''
+    try:
+        shutil.rmtree(os.path.join(dropbox_path, "sample"))
+    except OSError as e:
+        print("Error during cleanup: %s : %s" % (os.path.join(dropbox_path, "sample/batch.xml.failed"), e.strerror))


### PR DESCRIPTION
**Handles the load report and batch failed api calls*
* * *

**GitHub Issue**: https://github.com/harvard-lts/HDC/issues/201

# How should this be tested?

1. Clone the repo
2. Checkout the branch HDC_201
3. Copy the env-template.txt to .env
4. Get the credentials from LPE Shared-HDC/Dev/QA ims ActiveMQ (transfer and process) for ims-process-dev
5. Add the credentials from step 4 to the .env for the PROCESS queueing and DRS 
6. Set .env variables:
```
DRS_QUEUE_CONSUME_NAME=/queue/mock-drs-ingest-complete-local
DRS_QUEUE_PUBLISH_NAME=/queue/mock-drs-ingest-trigger-local
PROCESS_QUEUE_CONSUME_NAME=/queue/dims-data-ready-mock-local
PROCESS_QUEUE_PUBLISH_NAME=/queue/drs-ingest-status-local
```
8. Start up the docker container: `docker-compose -f docker-compose-local.yml up -d --build --force-recreate`
9. Exec into the container: `docker exec -it translation-service bash`
10. Run the command `pytest`

# Test coverage
Yes/No: Are changes in this pull-request covered by:
- unit tests? yes
- integration tests? no
