### PR TITLE
Add appuser to guestftp group

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,8 +18,8 @@ RUN apt-get update && apt-get install -y curl libpq-dev gcc python-dev superviso
   pip install gunicorn && \
   pip install --upgrade --force-reinstall -r /tmp/requirements.txt -i https://pypi.org/simple/ --extra-index-url https://test.pypi.org/simple/ &&\
   groupadd -r -g 55020 appuser && \
-  groupadd -r -g 4000 appuser && \
   useradd -u 55020 -g 55020 --create-home appuser
+  useradd -G 4000 appuser
 
 # Supervisor to run and manage multiple apps in the same container
 ADD supervisord.conf /etc/supervisor/conf.d/supervisord.conf

--- a/Dockerfile
+++ b/Dockerfile
@@ -18,6 +18,7 @@ RUN apt-get update && apt-get install -y curl libpq-dev gcc python-dev superviso
   pip install gunicorn && \
   pip install --upgrade --force-reinstall -r /tmp/requirements.txt -i https://pypi.org/simple/ --extra-index-url https://test.pypi.org/simple/ &&\
   groupadd -r -g 55020 appuser && \
+  groupadd -r -g 4000 appuser && \
   useradd -u 55020 -g 55020 --create-home appuser
 
 # Supervisor to run and manage multiple apps in the same container
@@ -37,7 +38,8 @@ RUN rm -f /etc/nginx/sites-enabled/default && \
     chown -R appuser /var/log/nginx && \
     chown -R appuser /var/lib/nginx && \
     chown -R appuser /data && \
-    chown -R appuser /run
+    chown -R appuser /run && \
+    chmod -R 755 /drs2dev/drsfs/dropbox/dvndev/incoming/
 
 WORKDIR /home/appuser
 USER appuser

--- a/Dockerfile
+++ b/Dockerfile
@@ -18,8 +18,8 @@ RUN apt-get update && apt-get install -y curl libpq-dev gcc python-dev superviso
   pip install gunicorn && \
   pip install --upgrade --force-reinstall -r /tmp/requirements.txt -i https://pypi.org/simple/ --extra-index-url https://test.pypi.org/simple/ &&\
   groupadd -r -g 55020 appuser && \
-  useradd -u 55020 -g 55020 --create-home appuser
-  useradd -G 4000 appuser
+  groupadd -r -g 4000 guestftp && \
+  useradd -u 55020 -g 55020 -G 4000 --create-home appuser
 
 # Supervisor to run and manage multiple apps in the same container
 ADD supervisord.conf /etc/supervisor/conf.d/supervisord.conf
@@ -38,8 +38,7 @@ RUN rm -f /etc/nginx/sites-enabled/default && \
     chown -R appuser /var/log/nginx && \
     chown -R appuser /var/lib/nginx && \
     chown -R appuser /data && \
-    chown -R appuser /run && \
-    chmod -R 755 /drs2dev/drsfs/dropbox/dvndev/incoming/
+    chown -R appuser /run
 
 WORKDIR /home/appuser
 USER appuser


### PR DESCRIPTION
Add appuser to guestftp group
* * *

**GitHub Issue**: (HDC#226)

# What does this Pull Request do?
This PR adds appuser to the guestftp group to allow DRS to write to the batch directory during ingest

# How should this be tested?

Tested on Trial

# Test coverage
Yes/No: Are changes in this pull-request covered by:
- unit tests? n/a
- integration tests? n/a

# Interested parties
@GPortas 
