### PR TITLE
DTS Updates to accommodate ePADD

### DIFF
--- a/app/mqresources/listener/process_ready_queue_listener.py
+++ b/app/mqresources/listener/process_ready_queue_listener.py
@@ -28,13 +28,17 @@ class ProcessReadyQueueListener(StompListenerBase):
             )
         )
         try:
+            testing = False
+            if "testing" in message_body:
+                testing = True
             # This calls a method to handle prepping the batch for distribution to the DRS
             translation_service.prepare_and_send_to_drs(
                 os.path.join(
                     message_body["destination_path"],
                     message_body["package_id"]
                 ),
-                message_body['admin_metadata']
+                message_body['admin_metadata'],
+                testing
             )
         except Exception:
             mqutils.notify_ingest_status_process_message(message_body.get("package_id"), "failure")

--- a/app/translation_service/translate_data_structure_service.py
+++ b/app/translation_service/translate_data_structure_service.py
@@ -1,4 +1,4 @@
-import os, os.path, logging, shutil
+import os, os.path, logging, shutil, glob
 
 logfile=os.getenv('LOGFILE_PATH', 'drs_translation_service')
 loglevel=os.getenv('LOGLEVEL', 'WARNING')
@@ -25,46 +25,57 @@ def translate_data_structure(package_path):
     if (len(extracted_files) != 1):
         raise Exception("{} directory expected 1 item but found {}".format(extracted_files_dir, len(extracted_files)))    
     
-    data_dir = os.path.join(extracted_files_dir, extracted_files[0], "data")
+    extracted_path = os.path.join(extracted_files_dir, extracted_files[0])
     
-    if os.path.exists(data_dir):
-        logging.debug("Moving content for {}".format(data_dir))
-        content_path = os.path.join(object_dir, "content")
-        if not os.path.exists(content_path):
-            os.mkdir(content_path)
-        __move_content_files(data_dir, content_path)
-        hascontent = True
-    else:
-        hascontent = False
-        logging.debug("No contents exist in {}".format(data_dir))
+    hascontent = __handle_content_files(object_dir, extracted_path)
     
     __copy_project_conf(package_path)
     __copy_object_xml_and_rename_object(aux_object_dir, hascontent)
-        
-    doc_path = os.path.join(object_dir, "documentation")
-    if not os.path.exists(doc_path):
-        os.mkdir(doc_path)
-    __move_document_files(os.path.join(extracted_files_dir, extracted_files[0]), doc_path)
     
-    #Move the DDI file (ends in XML)
-    for f in os.listdir(package_path):
-        if os.path.isfile(os.path.join(package_path, f)):
-            if f.endswith(".xml"):
-                __move_files(package_path, os.path.join(package_path, f), doc_path)
+    __handle_documentation_files(object_dir, extracted_path)
                 
     return batch_dir
 
-def __move_content_files(data_dir, content_path):
-    __move_files(data_dir, data_dir, content_path)
-    return True
+def __handle_content_files(object_dir, extracted_path):
+    content_list_string = os.getenv("CONTENT_FILES_AND_DIRS", "")
+    content_list = content_list_string.split(",")
+    
+    hascontent = False
+    for item in content_list:
+        item_path = os.path.join(extracted_path, item)
+    
+         #If there is a wildcard, then move all under that item
+        if ("*" in item):
+            for file in glob.glob(r'{}'.format(item_path)):
+                shutil.copy2(file, os.path.join(doc_path, file)) 
+        elif os.path.exists(item_path):
+            logging.debug("Moving content for {}".format(item_path))
+            content_path = os.path.join(object_dir, "content")
+            if not os.path.exists(content_path):
+                os.mkdir(content_path)
+            #If it is a path to a file, move the file
+            if (os.path.isfile(item_path)): 
+                print("Moving {} to {}".format(item_path, os.path.join(dest_dir, os.path.basename(item_path))))
+                logging.debug("Moving {} to {}".format(item_path, os.path.basename(item_path)))
+                shutil.copy2(item_path, os.path.join(dest_dir, os.path.basename(item_path)))
+            #If it is a directory, use the recursive call
+            else:
+                __move_files(item_path, item_path, content_path)
+            hascontent = True
+        else:
+            hascontent = False
+            logging.debug("No contents exist in {}".format(dir))
+    
+    return hascontent
 
-def __move_files(root, source, dest_dir):
+
+def __move_files(root_dir, source, dest_dir):
     '''This method actually copies the files from source to destination rather than
     moves them to preserve the original structure and to aid in error handling'''
     if (os.path.isfile(source)):
-        print("Moving {} to {}".format(os.path.join(root, source), os.path.join(dest_dir, source)))
-        logging.debug("Moving {} to {}".format(os.path.join(root, source), os.path.join(dest_dir, source)))
-        shutil.copy2(os.path.join(root, source), os.path.join(dest_dir, os.path.basename(source)))
+        print("Moving {} to {}".format(os.path.join(root_dir, source), os.path.join(dest_dir, source)))
+        logging.debug("Moving {} to {}".format(os.path.join(root_dir, source), os.path.join(dest_dir, source)))
+        shutil.copy2(os.path.join(root_dir, source), os.path.join(dest_dir, os.path.basename(source)))
     else:
         for root, subdirs, files in os.walk(source):
             for subdir in subdirs:
@@ -74,22 +85,33 @@ def __move_files(root, source, dest_dir):
                 print("File {} to {}".format(os.path.join(root, filename), os.path.join(dest_dir, filename)))
                 shutil.copy2(os.path.join(root, filename), os.path.join(dest_dir, filename))
 
-def __move_document_files(extracted_dir, doc_path):
-    #Move the files in the extracted directory (bag-it info, manifest info)
-    for f in os.listdir(extracted_dir):
-        print(os.path.join(extracted_dir, f))
-        if os.path.isfile(os.path.join(extracted_dir, f)):
-            __move_files(extracted_dir, os.path.join(extracted_dir, f), doc_path)
-        
-    md_dir = os.path.join(extracted_dir, "metadata")
-    if os.path.exists(md_dir):
-        logging.debug("Moving docs for {}".format(md_dir))
-        #Move the files in the metadata directory
-        __move_files(md_dir, md_dir, doc_path)
-    else:
-        logging.debug("No docs exist in {}".format(md_dir))
-    md_dir = os.path.join(extracted_dir, "metadata")
-    return True
+def __handle_documentation_files(object_dir, extracted_path):
+    documentation_list_string = os.getenv("DOCUMENTATION_FILES_AND_DIRS", "")
+    documentation_list = documentation_list_string.split(",")
+    
+    for item in documentation_list:
+        item_path = os.path.join(extracted_path, item)
+        #If there is a wildcard, then move all under that item
+        if ("*" in item):
+            print("Wildcard {} ".format(item_path))
+            print(glob.glob('{}'.format(item_path)))
+            for file in glob.glob('{}'.format(item_path)):
+                print("file: {}".format(file))
+                shutil.copy2(os.path.join(item_path,file), os.path.join(doc_path, file)) 
+        elif os.path.exists(item_path):
+            doc_path = os.path.join(object_dir, "documentation")
+            if not os.path.exists(doc_path):
+                os.mkdir(doc_path)
+                
+            #If it is a path to a file, move the file
+            if (os.path.isfile(item_path)): 
+                print("Moving {} to {}".format(item_path, os.path.join(doc_path, os.path.basename(item_path))))
+                logging.debug("Moving {} to {}".format(item_path, os.path.basename(item_path)))
+                shutil.copy2(item_path, os.path.join(doc_path, os.path.basename(item_path)))
+            #If it is a directory, use the recursive call
+            else:
+                __move_files(item_path, item_path, doc_path)
+    
 
 def __copy_project_conf(project_dir):
     project_conf = os.getenv("PROJECT_CONF_TEMPLATE")

--- a/app/translation_service/translate_data_structure_service.py
+++ b/app/translation_service/translate_data_structure_service.py
@@ -44,20 +44,21 @@ def __handle_content_files(object_dir, extracted_path):
     for item in content_list:
         item_path = os.path.join(extracted_path, item)
     
+        content_path = os.path.join(object_dir, "content")
+            
          #If there is a wildcard, then move all under that item
         if ("*" in item):
             for file in glob.glob(r'{}'.format(item_path)):
-                shutil.copy2(file, os.path.join(doc_path, file)) 
+                shutil.copy2(file, os.path.join(content_path, file)) 
         elif os.path.exists(item_path):
             logging.debug("Moving content for {}".format(item_path))
-            content_path = os.path.join(object_dir, "content")
             if not os.path.exists(content_path):
                 os.mkdir(content_path)
             #If it is a path to a file, move the file
             if (os.path.isfile(item_path)): 
-                print("Moving {} to {}".format(item_path, os.path.join(dest_dir, os.path.basename(item_path))))
+                print("Moving {} to {}".format(item_path, os.path.join(content_path, os.path.basename(item_path))))
                 logging.debug("Moving {} to {}".format(item_path, os.path.basename(item_path)))
-                shutil.copy2(item_path, os.path.join(dest_dir, os.path.basename(item_path)))
+                shutil.copy2(item_path, os.path.join(content_path, os.path.basename(item_path)))
             #If it is a directory, use the recursive call
             else:
                 __move_files(item_path, item_path, content_path)
@@ -89,6 +90,7 @@ def __handle_documentation_files(object_dir, extracted_path):
     documentation_list_string = os.getenv("DOCUMENTATION_FILES_AND_DIRS", "")
     documentation_list = documentation_list_string.split(",")
     
+    doc_path = os.path.join(object_dir, "documentation")
     for item in documentation_list:
         item_path = os.path.join(extracted_path, item)
         #If there is a wildcard, then move all under that item
@@ -99,7 +101,6 @@ def __handle_documentation_files(object_dir, extracted_path):
                 print("file: {}".format(file))
                 shutil.copy2(os.path.join(item_path,file), os.path.join(doc_path, file)) 
         elif os.path.exists(item_path):
-            doc_path = os.path.join(object_dir, "documentation")
             if not os.path.exists(doc_path):
                 os.mkdir(doc_path)
                 

--- a/app/translation_service/translation_service.py
+++ b/app/translation_service/translation_service.py
@@ -8,7 +8,7 @@ logging.basicConfig(filename=logfile, level=loglevel)
 
 batch_builder_assistant = BatchBuilderAssistant()
 
-def prepare_and_send_to_drs(package_dir, supplemental_deposit_data):
+def prepare_and_send_to_drs(package_dir, supplemental_deposit_data, testing = False):
     #Set up directories
     batch_dir = translate_data_structure_service.translate_data_structure(package_dir)
     #Run BB
@@ -20,11 +20,12 @@ def prepare_and_send_to_drs(package_dir, supplemental_deposit_data):
     #Remove old project dir
     __cleanup_project_dir(package_dir)
     
-    #Add LOADING file to package directory
-    __create_loading_file(batch_dir)
-
     #Update batch_dir permissions
     __update_permissions(batch_dir)
+    
+    #Add LOADING file to package directory if we are not testing
+    if not testing:
+        __create_loading_file(batch_dir)
     
     return batch_dir
 

--- a/app/translation_service/translation_service.py
+++ b/app/translation_service/translation_service.py
@@ -2,6 +2,8 @@ import os, os.path, logging, shutil
 import translation_service.translate_data_structure_service as translate_data_structure_service
 from translation_service.batch_builder_assistant import BatchBuilderAssistant
 
+load_report_dir = os.getenv("LOADREPORT_PATH")
+sample_load_report="/home/appuser/tests/data/sampleloadreport/LOADREPORT_sample.txt"
 logfile=os.getenv('LOGFILE_PATH', 'drs_translation_service')
 loglevel=os.getenv('LOGLEVEL', 'WARNING')
 logging.basicConfig(filename=logfile, level=loglevel)
@@ -26,6 +28,9 @@ def prepare_and_send_to_drs(package_dir, supplemental_deposit_data, testing = Fa
     #Add LOADING file to package directory if we are not testing
     if not testing:
         __create_loading_file(batch_dir)
+    #If testing, place a mock load report to allow for the flow to continue
+    else:
+        __place_mock_load_report(os.path.basename(batch_dir))
     
     return batch_dir
 
@@ -60,3 +65,13 @@ def __update_permissions(batch_dir):
             os.chmod(os.path.join(root, file), 0o775)
     os.chown(batch_dir, 55020, 4000)
     os.chmod(batch_dir, 0o775)
+    
+    
+def __place_mock_load_report(batch_name):
+    batch_load_report_dir = os.path.join(load_report_dir, batch_name)
+    #Create dir in LR dir
+    os.mkdir(batch_load_report_dir)
+    
+    mock_load_report_name = "LOADREPORT_{}.txt".format(batch_name)
+    mock_load_report_dest = os.path.join(batch_load_report_dir, mock_load_report_name)
+    shutil.copy(sample_load_report, mock_load_report_dest)

--- a/env-template.txt
+++ b/env-template.txt
@@ -7,7 +7,7 @@ LOGLEVEL=DEBUG
 
 PYTHONPATH=/home/appuser/app
 #Default to one hour
-MESSAGE_EXPIRATION_MS=60000
+MESSAGE_EXPIRATION_MS=3600000
 
 NRS_PREFIX=https://nrs-dev.harvard.edu
 
@@ -27,3 +27,20 @@ OBJECT_XML_TEMPLATE=/home/appuser/app/bbtemplates/object.xml.template
 OBJECT_XML_DOC_ONLY_TEMPLATE=/home/appuser/app/bbtemplates/object.xml.documentationonly.template
 BB_SCRIPT_NAME=batchbuildercli.sh
 BB_CLIENT_PATH=/home/batchbuilder
+
+#Right now we are using the opaque content model for ePADD and DVN
+#If another CM is used, then the mapping will need to be mapping will have to be created
+CONTENT_MODEL=opaque
+
+#Opaque setup
+#List the relative paths for the files or directories that should go into the content directory
+#Note, all files under each directory will be flattened into its designated directory.
+#Listing a directory will place all files in that directory into the designated directory.  To select
+#individual files, you will have to list the path for each.
+#For all files of a certain type, you can use the wildcard * such as *.txt.  Please know that the algorithm
+#is not currently setup to retrieve files using regex such as 'abc*.txt'
+
+#Files/dirs to be moved the content directory
+CONTENT_FILES_AND_DIRS=data
+#Files/dirs to be moved to the documentation directory
+DOCUMENTATION_FILES_AND_DIRS=metadata,bag-info.txt,bagit.txt,manifest-md5.txt,*.xml

--- a/tests/unit/test_translate_data_structure_service.py
+++ b/tests/unit/test_translate_data_structure_service.py
@@ -26,7 +26,6 @@ def test_translate_data_structure():
     assert os.path.exists(os.path.join(obj_dir, "documentation", "datacite.xml"))
     assert os.path.exists(os.path.join(obj_dir, "documentation", "oai-ore.jsonld"))
     assert os.path.exists(os.path.join(obj_dir, "documentation", "pid-mapping.txt"))
-    assert os.path.exists(os.path.join(obj_dir, "documentation", "doi-translation-service-test_datacite.v1.0.xml"))
     cleanup_batch_dirs(batch_dir, os.path.join(loc, "_aux"), os.path.join(loc, "project.conf"))
 
 def test_translate_data_structure_doc_only():
@@ -51,7 +50,6 @@ def test_translate_data_structure_doc_only():
     assert os.path.exists(os.path.join(obj_dir, "documentation", "datacite.xml"))
     assert os.path.exists(os.path.join(obj_dir, "documentation", "oai-ore.jsonld"))
     assert os.path.exists(os.path.join(obj_dir, "documentation", "pid-mapping.txt"))
-    assert os.path.exists(os.path.join(obj_dir, "documentation", "doi-translation-service-test_datacite.v1.0.xml"))
     cleanup_batch_dirs(batch_dir, os.path.join(loc, "_aux"), os.path.join(loc, "project.conf"))   
      
 def cleanup_batch_dirs(batch_path, aux_dir, project_conf):

--- a/tests/unit/test_translation_service.py
+++ b/tests/unit/test_translation_service.py
@@ -3,7 +3,8 @@ sys.path.append('app')
 import translation_service.translation_service as translation_service 
 
 dropbox = os.getenv("DROPBOX_PATH")
-    
+load_report_dir = os.getenv("LOADREPORT_PATH")
+   
 def test_prepare_and_send_to_drs():
     '''Formats the directory and verifies that all files ended up where they should be'''
     loc = "/home/appuser/tests/data/doi-translation-service-test"
@@ -21,10 +22,37 @@ def test_prepare_and_send_to_drs():
     #Remove the files
     cleanup_batch(batch_dir)
 
+def test_prepare_and_create_mock_lr():
+    '''Formats the directory and verifies that all files ended up where they should be'''
+    loc = "/home/appuser/tests/data/doi-translation-service-test"
+    package_dir = os.path.join(dropbox, os.path.basename(loc))
+    
+    #Copy the data from the loc to the dropbox
+    shutil.copytree(loc, package_dir)
+    
+    #Run prepare
+    batch_dir = translation_service.prepare_and_send_to_drs(package_dir, {}, True)
+    
+    mock_lr_name = "LOADREPORT_{}.txt".format(os.path.basename(batch_dir))
+    mock_lr = os.path.join(load_report_dir, os.path.basename(batch_dir), mock_lr_name)
+    #Check that the loading file exists
+    assert os.path.exists(mock_lr)
+    
+    #Remove the files
+    cleanup_mock_loadreport(mock_lr)
+
 
 def cleanup_batch(batch_dir):
     '''Removes the batch from the dropbox'''
     try:
         shutil.rmtree(batch_dir)
+    except OSError as e:
+        print("Error in cleanup: %s" % (e.strerror))
+        
+def cleanup_mock_loadreport(mock_lr):
+    '''Removes the batch from the dropbox'''
+    try:
+        os.remove(mock_lr)
+        os.rmdir(os.path.dirname(mock_lr))
     except OSError as e:
         print("Error in cleanup: %s" % (e.strerror))

--- a/tests/unit/test_translation_service.py
+++ b/tests/unit/test_translation_service.py
@@ -39,6 +39,8 @@ def test_prepare_and_create_mock_lr():
     assert os.path.exists(mock_lr)
     
     #Remove the files
+    cleanup_batch(batch_dir)
+    #Remove the files
     cleanup_mock_loadreport(mock_lr)
 
 


### PR DESCRIPTION
**Updates to DTS to accommodate ePADD**
* * *

**GitHub Issue**: https://github.com/harvard-lts/epadd/issues/27

# What does this Pull Request do?
DTS has a ‘testing’ trigger which will cause DTS not to place the LOADING file (integration tests)
DTS places a mock Load report for cron to pick up (if testing trigger exists)
DTS uses a mapping in the .env to supply content and documentation files

# How should this be tested?

Please note the new environment variables in this release (see the env-template.txt for comparison)

1. Clone the repo
2. Checkout the branch epadd-27
3. Copy the env-template.txt to .env
4. Get the credentials from LPE Shared-DAIS/Dev/QA ims ActiveMQ (transfer and process) for ims-process-dev
5. Add the credentials from step 4 to the .env for the PROCESS queueing
6. Set .env variables:
```
PROCESS_QUEUE_CONSUME_NAME=/queue/dims-data-ready-mock-local
PROCESS_QUEUE_PUBLISH_NAME=/queue/drs-ingest-status-local
```
7. Start up the docker container: `docker-compose -f docker-compose-local.yml up -d --build --force-recreate`
8. Exec into the container: `docker exec -it translation-service bash`
9. Run the command `pytest`

# Test coverage
Yes/No: Are changes in this pull-request covered by:
- unit tests? yes
- integration tests? no

