### PR TITLE
Add application_name param for batch translation

### DIFF
--- a/app/mqresources/listener/process_ready_queue_listener.py
+++ b/app/mqresources/listener/process_ready_queue_listener.py
@@ -39,6 +39,7 @@ class ProcessReadyQueueListener(StompListenerBase):
                     message_body["package_id"]
                 ),
                 message_body['admin_metadata'],
+                message_body['application_name'],
                 testing
             )
         except Exception:

--- a/app/translation_service/translate_data_structure_service.py
+++ b/app/translation_service/translate_data_structure_service.py
@@ -4,7 +4,7 @@ logfile=os.getenv('LOGFILE_PATH', 'drs_translation_service')
 loglevel=os.getenv('LOGLEVEL', 'WARNING')
 logging.basicConfig(filename=logfile, level=loglevel)
 
-def translate_data_structure(package_path, supplemental_deposit_data):
+def translate_data_structure(package_path, supplemental_deposit_data, depositing_application):
     #Project name is the doi-name
     #Batch name doi-name-batch
     batch_name= os.path.basename(package_path) + "-batch"
@@ -17,7 +17,7 @@ def translate_data_structure(package_path, supplemental_deposit_data):
     os.makedirs(aux_object_dir, exist_ok=True)
     os.makedirs(object_dir, exist_ok=True)
     
-    application_name = supplemental_deposit_data["application_name"]
+    application_name = depositing_application
     if (application_name == "Dataverse"):
         is_extracted_package = os.getenv("EXTRACTED_PACKAGE_DVN", 'False').lower()
         content_model = os.getenv("DVN_CONTENT_MODEL", "opaque")

--- a/app/translation_service/translation_service.py
+++ b/app/translation_service/translation_service.py
@@ -10,9 +10,9 @@ logging.basicConfig(filename=logfile, level=loglevel)
 
 batch_builder_assistant = BatchBuilderAssistant()
 
-def prepare_and_send_to_drs(package_dir, supplemental_deposit_data, testing = False):
+def prepare_and_send_to_drs(package_dir, supplemental_deposit_data, depositing_application, testing = False):
     #Set up directories
-    batch_dir = translate_data_structure_service.translate_data_structure(package_dir, supplemental_deposit_data)
+    batch_dir = translate_data_structure_service.translate_data_structure(package_dir, supplemental_deposit_data, depositing_application)
     #Run BB
     batch_builder_assistant.process_batch(package_dir, os.path.basename(batch_dir), supplemental_deposit_data)
     

--- a/tests/unit/test_translation_service.py
+++ b/tests/unit/test_translation_service.py
@@ -20,7 +20,7 @@ def test_prepare_and_create_mock_lr():
     shutil.copytree(loc, package_dir)
     
     #Run prepare
-    batch_dir = translation_service.prepare_and_send_to_drs(package_dir, {"application_name": "Dataverse", "dropbox_name": dropbox_name_for_testing}, True)
+    batch_dir = translation_service.prepare_and_send_to_drs(package_dir, {"dropbox_name": dropbox_name_for_testing}, "Dataverse", True)
 
     mock_lr_name = "LOADREPORT_{}.txt".format(os.path.basename(batch_dir))
     mock_lr = os.path.join(base_load_report_dir, dropbox_name_for_testing, os.path.basename(batch_dir), mock_lr_name)


### PR DESCRIPTION
**Add application_name param for batch translation*
* * *

**GitHub Issue**: [epadd#44](https://app.zenhub.com/workspaces/epadd-harvard-62c485cd49f954001312ebdd/issues/harvard-lts/epadd/44)

# What does this Pull Request do?
Application name is expected in the implementation of `translate_data_structure()` but is not passed in the `supplemental_deposit_data` param. This edit includes the application name as it's own parameter.

# How should this be tested?

Deploy to QA and publish a test dataset

# Test coverage
Yes/No: Are changes in this pull-request covered by:
- unit tests? yes
- integration tests? n/a

# Interested parties
@ives1227 @dl-maura @awoods 
