### PR TITLE
Reinstating the use of the DLX and DLQ

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ pytest
 
 - Bring up [DEV DAIS Rabbit UI](https://b-e9f45d5f-039d-4226-b5df-1a776c736346.mq.us-east-1.amazonaws.com/)  - credentials in LPE Shared-DAIS
 
-- Look for the DLQ queue that you named in your .env (eg `dais-dead-letter-queue-dd`) verify the message lands here
+- Look for the DLQ queue (`dais-dead-letter-queue`) verify the message lands here
 
 ## DLX/DLQ
 

--- a/README.md
+++ b/README.md
@@ -57,3 +57,6 @@ pytest
 
 - Look for the DLQ queue that you named in your .env (eg `dais-dead-letter-queue-dd`) verify the message lands here
 
+## DLX/DLQ
+
+The DAIS services use a dead letter queue to collect messages that were rejected after a configurable amount of retries.  Information on the DLX/DLQ setup and use can be found on this [LTS internal wiki](https://wiki.harvard.edu/confluence/pages/viewpage.action?pageId=337150659).

--- a/app/load_report_service/load_report_service.py
+++ b/app/load_report_service/load_report_service.py
@@ -2,6 +2,7 @@ import os, os.path, shutil
 from load_report_service.load_report import LoadReport
 from load_report_service.load_report_exception import LoadReportException
 from celery import Celery
+from kombu import Queue
 
 base_load_report_dir = os.getenv("BASE_LOADREPORT_PATH")
 base_dropbox_dir = os.getenv("BASE_DROPBOX_PATH")
@@ -75,8 +76,10 @@ def handle_load_report(load_report_name, dry_run = False):
             "retry_count": 0
         }
     }
+    publish_queue = Queue(
+        os.getenv("PROCESS_PUBLISH_QUEUE_NAME"), no_declare=True)
     app.send_task(process_status_task, args=[msg_json], kwargs={},
-                  queue=os.getenv("PROCESS_PUBLISH_QUEUE_NAME"))
+                  queue=publish_queue)
     return urn
     
 
@@ -99,8 +102,10 @@ def handle_failed_batch(batch_name, dry_run = False):
             "retry_count": 0
         }
     }
+    publish_queue = Queue(
+        os.getenv("PROCESS_PUBLISH_QUEUE_NAME"), no_declare=True)
     app.send_task(process_status_task, args=[msg_json], kwargs={},
-                  queue=os.getenv("PROCESS_PUBLISH_QUEUE_NAME"))
+                  queue=publish_queue)
 
     #Delete batch from dropbox
     # TODO: Fix delete

--- a/celeryconfig.py
+++ b/celeryconfig.py
@@ -11,24 +11,24 @@ enable_utc = True
 worker_enable_remote_control = False
 
 #DLQ Routing
-# dead_letter_queue_option = {
-#     'x-dead-letter-exchange': os.getenv("DLQ_EXCHANGE_NAME"),
-#     'x-dead-letter-routing-key': os.getenv("DLQ_QUEUE_NAME")
-# #    'x-message-ttl': int(os.getenv('MESSAGE_EXPIRATION_MS', 3600000))
-# }
-# 
-# default_exchange = Exchange(os.getenv("PROCESS_CONSUME_QUEUE_NAME"), type='direct')
-# default_queue = Queue(
-#     os.getenv("PROCESS_CONSUME_QUEUE_NAME"),
-#     default_exchange,
-#     routing_key=os.getenv("PROCESS_CONSUME_QUEUE_NAME"),
-#     queue_arguments=dead_letter_queue_option)
-# 
-# dlx_exchange = Exchange(os.getenv("DLQ_EXCHANGE_NAME"), type='direct')
-# dead_letter_queue = Queue(
-#     os.getenv("DLQ_QUEUE_NAME"), dlx_exchange, routing_key=os.getenv("DLQ_QUEUE_NAME"))
-# 
-# task_queues = [default_queue]
+dead_letter_queue_option = {
+    'x-dead-letter-exchange': os.getenv("DLQ_EXCHANGE_NAME"),
+    'x-dead-letter-routing-key': os.getenv("DLQ_QUEUE_NAME"),
+    'x-message-ttl': int(os.getenv('MESSAGE_EXPIRATION_MS', 3600000))
+}
+ 
+default_exchange = Exchange(os.getenv("PROCESS_CONSUME_QUEUE_NAME"), type='direct')
+default_queue = Queue(
+    os.getenv("PROCESS_CONSUME_QUEUE_NAME"),
+    default_exchange,
+    routing_key=os.getenv("PROCESS_CONSUME_QUEUE_NAME"),
+    queue_arguments=dead_letter_queue_option)
+ 
+dlx_exchange = Exchange(os.getenv("DLQ_EXCHANGE_NAME"), type='direct')
+dead_letter_queue = Queue(
+    os.getenv("DLQ_QUEUE_NAME"), dlx_exchange, routing_key=os.getenv("DLQ_QUEUE_NAME"))
+ 
+task_queues = [default_queue]
 task_routes = {
     'dts.tasks.prepare_and_send_to_drs':
         {'queue': os.getenv("PROCESS_CONSUME_QUEUE_NAME")}

--- a/celeryconfig.py
+++ b/celeryconfig.py
@@ -16,17 +16,17 @@ dead_letter_queue_option = {
     'x-dead-letter-routing-key': os.getenv("DLQ_QUEUE_NAME"),
     'x-message-ttl': int(os.getenv('MESSAGE_EXPIRATION_MS', 3600000))
 }
- 
+
+# Set the default exchange to the same as the queue name
 default_exchange = Exchange(os.getenv("PROCESS_CONSUME_QUEUE_NAME"), type='direct')
+
+# Create the Queue and pass the DLQ options to it
+# This will route any failed messages to the DLQ
 default_queue = Queue(
     os.getenv("PROCESS_CONSUME_QUEUE_NAME"),
     default_exchange,
     routing_key=os.getenv("PROCESS_CONSUME_QUEUE_NAME"),
     queue_arguments=dead_letter_queue_option)
- 
-dlx_exchange = Exchange(os.getenv("DLQ_EXCHANGE_NAME"), type='direct')
-dead_letter_queue = Queue(
-    os.getenv("DLQ_QUEUE_NAME"), dlx_exchange, routing_key=os.getenv("DLQ_QUEUE_NAME"))
  
 task_queues = [default_queue]
 task_routes = {


### PR DESCRIPTION
**Reinstating the use of the DLX and DLQ**
* * *

**GitHub Issue**: https://jira.huit.harvard.edu/browse/ETD-210

# What does this Pull Request do?
Allows the use of the DLQ/DLX without errors when publishing tasks to a queue that has a custom DLQ.  The requirement was to add `no_declare=True` to `send_task` calls when publishing to a queue that is consumed by another service.

# How should this be tested?
1. Copy env.example and populate proper values
2. Run the pytests by following the [README instructions](https://github.com/harvard-lts/drs-translation-service/tree/ETD-210#testing)
3. Run the invoke-dlq-task explained in the [README](https://github.com/harvard-lts/drs-translation-service/tree/ETD-210#invoke-dlq-taskpy-add-message-that-will-be-rejected-to-the-queue)

# Test coverage
Yes/No: Are changes in this pull-request covered by:
- unit tests? no
- integration tests? yes