### PR TITLE
New project.conf and object.xml templates

### DIFF
--- a/app/bbtemplates/object.xml.template_audio
+++ b/app/bbtemplates/object.xml.template_audio
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Objectconfig cm="audio">
+    <directory name="OBJECT_NAME">
+        <metadataCategory name="objectMetadata">
+            <property name="accessFlag" value="N"/>
+            <property name="billingCode" value="HUL.TEST.BILL.0001"/>
+            <property name="ownerCode" value="HUL.TEST"/>
+        </metadataCategory>
+        <metadataCategory name="nrsMetadata">
+            <property name="resourceNamePattern" value="{n}"/>
+            <property name="urnAuthorityPath" value="HUL.GUEST"/>
+        </metadataCategory>
+        <directory name="audio">
+            <metadataCategory name="fileMetadata">
+                <property name="usageClass" value="LOWUSE"/>
+                <property name="fileAccessFlag" value="P"/>
+            </metadataCategory>
+        </directory>
+    </directory>
+</Objectconfig>

--- a/app/bbtemplates/object.xml.template_document
+++ b/app/bbtemplates/object.xml.template_document
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Objectconfig cm="document">
+    <directory name="OBJECT_NAME">
+        <metadataCategory name="objectMetadata">
+            <property name="billingCode" value="HUL.TEST.BILL.0001"/>
+            <property name="accessFlag" value="N"/>
+            <property name="ownerCode" value="HUL.TEST"/>
+        </metadataCategory>
+        <metadataCategory name="nrsMetadata">
+            <property name="resourceNamePattern" value="{n}"/>
+            <property name="urnAuthorityPath" value="HUL.GUEST"/>
+        </metadataCategory>
+        <directory name="document">
+            <metadataCategory name="fileMetadata">
+                <property name="isFirstGenerationInDrs" value="yes"/>
+                <property name="usageClass" value="LOWUSE"/>
+            </metadataCategory>
+        </directory>
+    </directory>
+</Objectconfig>

--- a/app/bbtemplates/object.xml.template_stillimage
+++ b/app/bbtemplates/object.xml.template_stillimage
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Objectconfig cm="still image">
+    <directory name="OBJECT_NAME">
+        <metadataCategory name="objectMetadata">
+            <property name="billingCode" value="HUL.TEST.BILL.0001"/>
+            <property name="ownerCode" value="HUL.TEST"/>
+            <property name="accessFlag" value="N"/>
+        </metadataCategory>
+        <metadataCategory name="nrsMetadata">
+            <property name="resourceNamePattern" value="{n}"/>
+            <property name="urnAuthorityPath" value="HUL.GUEST"/>
+        </metadataCategory>
+        <directory name="image">
+            <metadataCategory name="fileMetadata">
+                <property name="isFirstGenerationInDrs" value="yes"/>
+                <property name="usageClass" value="LOWUSE"/>
+            </metadataCategory>
+        </directory>
+    </directory>
+</Objectconfig>

--- a/app/bbtemplates/object.xml.template_text
+++ b/app/bbtemplates/object.xml.template_text
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Objectconfig cm="text">
+    <directory name="OBJECT_NAME">
+        <metadataCategory name="objectMetadata">
+            <property name="ownerCode" value="HUL.TEST"/>
+            <property name="billingCode" value="HUL.TEST.BILL.0001"/>
+            <property name="accessFlag" value="N"/>
+        </metadataCategory>
+        <metadataCategory name="nrsMetadata">
+            <property name="resourceNamePattern" value="{n}"/>
+            <property name="urnAuthorityPath" value="HUL.GUEST"/>
+        </metadataCategory>
+        <directory name="text">
+            <metadataCategory name="fileMetadata">
+                <property name="usageClass" value="LOWUSE"/>
+                <property name="fileAccessFlag" value="P"/>
+            </metadataCategory>
+        </directory>
+    </directory>
+</Objectconfig>

--- a/app/bbtemplates/project.conf_template_audio
+++ b/app/bbtemplates/project.conf_template_audio
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Projectconfig genre="audio">
+    <metadataCategory name="projectMetadata">
+        <property name="batchName" value="{owner}_{batchDir}_{yyyy}{mo}{dd}_{hh24}{mm}{ss}"/>
+        <property name="successMethod" value="all"/>
+        <property name="projectName" value="audio"/>
+        <property name="projectDescription" value=""/>
+        <property name="successEmail" value="DTS@HU.onmicrosoft.com"/>
+        <property name="failureEmail" value="DTS@HU.onmicrosoft.com"/>
+        <property name="depositAgentEmail" value="DTS@HU.onmicrosoft.com"/>
+        <property name="depositAgent" value="dimsdts1"/>
+    </metadataCategory>
+    <directory name="OBJECT TEMPLATE">
+        <metadataCategory name="objectMetadata">
+            <property name="accessFlag" value="N"/>
+            <property name="billingCode" value="HUL.TEST.BILL.0001"/>
+            <property name="ownerCode" value="HUL.TEST"/>
+        </metadataCategory>
+        <metadataCategory name="nrsMetadata">
+            <property name="resourceNamePattern" value="{n}"/>
+            <property name="urnAuthorityPath" value="HUL.GUEST"/>
+        </metadataCategory>
+    </directory>
+</Projectconfig>

--- a/app/bbtemplates/project.conf_template_document
+++ b/app/bbtemplates/project.conf_template_document
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Projectconfig genre="document">
+    <metadataCategory name="projectMetadata">
+        <property name="batchName" value="{owner}_{batchDir}_{yyyy}{mo}{dd}_{hh24}{mm}{ss}"/>
+        <property name="successMethod" value="all"/>
+        <property name="projectName" value="document"/>
+        <property name="projectDescription" value=""/>
+        <property name="successEmail" value="DTS@HU.onmicrosoft.com"/>
+        <property name="failureEmail" value="DTS@HU.onmicrosoft.com"/>
+        <property name="depositAgentEmail" value="DTS@HU.onmicrosoft.com"/>
+        <property name="depositAgent" value="dimsdts1"/>
+    </metadataCategory>
+    <directory name="OBJECT TEMPLATE">
+        <metadataCategory name="objectMetadata">
+            <property name="billingCode" value="HUL.TEST.BILL.0001"/>
+            <property name="accessFlag" value="N"/>
+            <property name="ownerCode" value="HUL.TEST"/>
+        </metadataCategory>
+        <metadataCategory name="nrsMetadata">
+            <property name="resourceNamePattern" value="{n}"/>
+            <property name="urnAuthorityPath" value="HUL.GUEST"/>
+        </metadataCategory>
+    </directory>
+</Projectconfig>

--- a/app/bbtemplates/project.conf_template_stillimage
+++ b/app/bbtemplates/project.conf_template_stillimage
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Projectconfig genre="still image">
+    <metadataCategory name="projectMetadata">
+        <property name="batchName" value="{owner}_{batchDir}_{yyyy}{mo}{dd}_{hh24}{mm}{ss}"/>
+        <property name="successMethod" value="all"/>
+        <property name="projectName" value="image"/>
+        <property name="projectDescription" value=""/>
+        <property name="successEmail" value="DTS@HU.onmicrosoft.com"/>
+        <property name="failureEmail" value="DTS@HU.onmicrosoft.com"/>
+        <property name="depositAgentEmail" value="DTS@HU.onmicrosoft.com"/>
+        <property name="depositAgent" value="dimsdts1"/>
+    </metadataCategory>
+    <directory name="OBJECT TEMPLATE">
+        <metadataCategory name="objectMetadata">
+            <property name="billingCode" value="HUL.TEST.BILL.0001"/>
+            <property name="ownerCode" value="HUL.TEST"/>
+            <property name="accessFlag" value="N"/>
+        </metadataCategory>
+        <metadataCategory name="nrsMetadata">
+            <property name="resourceNamePattern" value="{n}"/>
+            <property name="urnAuthorityPath" value="HUL.GUEST"/>
+        </metadataCategory>
+    </directory>
+</Projectconfig>

--- a/app/bbtemplates/project.conf_template_text
+++ b/app/bbtemplates/project.conf_template_text
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Projectconfig genre="text">
+    <metadataCategory name="projectMetadata">
+        <property name="batchName" value="{owner}_{batchDir}_{yyyy}{mo}{dd}_{hh24}{mm}{ss}"/>
+        <property name="successMethod" value="all"/>
+        <property name="projectName" value="text"/>
+        <property name="projectDescription" value=""/>
+        <property name="successEmail" value="DTS@HU.onmicrosoft.com"/>
+        <property name="failureEmail" value="DTS@HU.onmicrosoft.com"/>
+        <property name="depositAgentEmail" value="DTS@HU.onmicrosoft.com"/>
+        <property name="depositAgent" value="dimsdts1"/>
+    </metadataCategory>
+    <directory name="OBJECT TEMPLATE">
+        <metadataCategory name="objectMetadata">
+            <property name="ownerCode" value="HUL.TEST"/>
+            <property name="billingCode" value="HUL.TEST.BILL.0001"/>
+            <property name="accessFlag" value="N"/>
+        </metadataCategory>
+        <metadataCategory name="nrsMetadata">
+            <property name="resourceNamePattern" value="{n}"/>
+            <property name="urnAuthorityPath" value="HUL.GUEST"/>
+        </metadataCategory>
+    </directory>
+</Projectconfig>


### PR DESCRIPTION
**Adds document, still image, audio, and text templates for project.conf and object.xml *
* * *

**GitHub Issue**: https://jira.huit.harvard.edu/browse/ETD-137

# How should this be tested?
Visual inspection

# Test coverage
Yes/No: Are changes in this pull-request covered by:
- unit tests? no
- integration tests? no

