### PR TITLE
Etd 147 - Load Report Service Builder

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -1,9 +1,7 @@
 import logging, traceback, re
 import os, os.path
 from logging.handlers import TimedRotatingFileHandler
-
-
-from load_report_service.dataverse_load_report_service import DataverseLoadReportService
+from load_report_service.load_report_service_builder import LoadReportServiceBuilder
 import translation_service.translation_service as translation_service
 import werkzeug
 from flask import Flask, request
@@ -43,11 +41,14 @@ def create_app():
         args = request.args
         if ("filename" not in args):
             return 'Missing filename argument!', 400
+        if ("dropbox" not in args):
+            return 'Missing dropbox argument!', 400
         dryrun = False
         if ("dryrun" in args):
             dryrun = True
         try:
-            load_report_service = DataverseLoadReportService()
+            builder = LoadReportServiceBuilder()
+            load_report_service = builder.get_load_report_service(args['dropbox'])
             load_report_service.handle_load_report(args['filename'], dryrun)
         except LoadReportException as lre:
             msg = "Handling of load report failed: {}".format(str(lre))
@@ -69,12 +70,15 @@ def create_app():
         args = request.args
         if ("batchName" not in args):
             return 'Missing batchName argument!', 400
+        if ("dropbox" not in args):
+            return 'Missing dropbox argument!', 400
         dryrun = False
         if ("dryrun" in args):
             dryrun = True
 
         try:
-            load_report_service = DataverseLoadReportService()
+            builder = LoadReportServiceBuilder()
+            load_report_service = builder.get_load_report_service(args['dropbox'])
             load_report_service.handle_failed_batch(args['batchName'], dryrun)
         except LoadReportException as lre:
             msg = "Handling of failed batch returned an error: {}".format(str(lre))

--- a/app/load_report_service/load_report_service_builder.py
+++ b/app/load_report_service/load_report_service_builder.py
@@ -1,10 +1,16 @@
 from load_report_service.dataverse_load_report_service import DataverseLoadReportService
+import os
+import logging
 
 class LoadReportServiceBuilder():
     
+    def __init__(self):
+        self.logger = logging.getLogger("dts")
+    
     def get_load_report_service(self, dropbox_name):
         '''Get the load report name based on the dropbox name'''
+        self.logger.debug("Getting load report service for {}".format(dropbox_name))
         dvn_dropbox_name = os.getenv("DVN_DROPBOX_NAME", "dvndev")
         if dropbox_name == dvn_dropbox_name:
-            return "Dataverse"
+            return DataverseLoadReportService()
         return None

--- a/app/load_report_service/load_report_service_builder.py
+++ b/app/load_report_service/load_report_service_builder.py
@@ -1,0 +1,10 @@
+from load_report_service.dataverse_load_report_service import DataverseLoadReportService
+
+class LoadReportServiceBuilder():
+    
+    def get_load_report_service(self, dropbox_name):
+        '''Get the load report name based on the dropbox name'''
+        dvn_dropbox_name = os.getenv("DVN_DROPBOX_NAME", "dvndev")
+        if dropbox_name == dvn_dropbox_name:
+            return "Dataverse"
+        return None

--- a/env-template.txt
+++ b/env-template.txt
@@ -57,6 +57,10 @@ DROPBOX_NAMES=XXX
 #Leave blank if using locally, otherwise give one dropbox name that is used for testing
 TEST_DROPBOX_NAME=XXX
 
+#Dropbox name for the application (use dev names for testing/local)
+EPADD_DROPBOX_NAME=XXX
+DVN_DROPBOX_NAME=XXX
+
 #Was the exported package unzipped by the transfer service?
 #Dataverse = true
 EXTRACTED_PACKAGE_DVN=True

--- a/tests/unit/test_api_calls.py
+++ b/tests/unit/test_api_calls.py
@@ -8,7 +8,7 @@ base_load_report_dir = os.getenv("BASE_LOADREPORT_PATH")
 
 def test_valid_loadreport_call():
     unit_test_helper.deposit_sample_load_report()
-    response = requests.get("https://localhost:8443/loadreport?filename={}&dryrun=True".format(unit_test_helper.sample_load_report), verify=False)
+    response = requests.get("https://localhost:8443/loadreport?filename={}&dropbox={}&dryrun=True".format(unit_test_helper.sample_load_report, "dvndev"), verify=False)
     assert response.status_code == 200
     unit_test_helper.cleanup_sample_load_report()
     
@@ -17,11 +17,11 @@ def test_invalid_loadreport_call():
     assert response.status_code == 400
     
 def test_invalid_loadreport_no_such_filename_call():
-    response = requests.get("https://localhost:8443/loadreport?filename=abc", verify=False)
+    response = requests.get("https://localhost:8443/loadreport?filename=abc&dropbox=dvndev", verify=False)
     assert response.status_code == 400
 
 def test_valid_batchfailed_call():
-    response = requests.get("https://localhost:8443/failedBatch?batchName=sample&dryrun=True", verify=False)
+    response = requests.get("https://localhost:8443/failedBatch?batchName=sample&dropbox=dvndev&dryrun=True", verify=False)
     assert response.status_code == 200
     
 def test_invalid_batchfailed_call():
@@ -29,7 +29,7 @@ def test_invalid_batchfailed_call():
     assert response.status_code == 400
 
 def test_invalid_batchfailed_no_such_batch_call():
-    response = requests.get("https://localhost:8443/failedBatch?batchName=abc", verify=False)
+    response = requests.get("https://localhost:8443/failedBatch?batchName=abc&dropbox=dvndev", verify=False)
     # This will work because we are not deleting the dir, when we attempt to delete the dir this will
     # need to be changed back to 400
     assert response.status_code == 200

--- a/tests/unit/test_load_report_service.py
+++ b/tests/unit/test_load_report_service.py
@@ -1,6 +1,7 @@
-import pytest, sys, os.path, shutil
+import pytest, sys, os.path, shutil, os
 sys.path.append('app')
 from load_report_service.dataverse_load_report_service import DataverseLoadReportService
+from load_report_service.load_report_service_builder import LoadReportServiceBuilder
 import unit_test_helper
 
 nrs_prefix = os.getenv("NRS_PREFIX")
@@ -20,4 +21,17 @@ def test_handle_failed_batch():
     batch_name = load_report_service.handle_failed_batch("sample", True)
     assert batch_name == "sample"
     unit_test_helper.cleanup_sample_failed_batch()
+    
+def test_builder_dvn():
+    '''Tests that the service is the DVN service'''
+    builder = LoadReportServiceBuilder()
+    service = builder.get_load_report_service(os.getenv("DVN_DROPBOX_NAME"))
+    assert isinstance(service, DataverseLoadReportService)
+    
+def test_builder_epadd():
+    '''Tests that None is returned for ePADD since ePADD doesn't
+    use the load report service'''
+    builder = LoadReportServiceBuilder()
+    service = builder.get_load_report_service(os.getenv("EPADD_DROPBOX_NAME"))
+    assert service is None
             


### PR DESCRIPTION
**Creates the Load Report Service Builder**
* * *

**GitHub Issue**: https://jira.huit.harvard.edu/browse/ETD-147

* Other Relevant Links (Mailing list discussion, related pull requests, etc.)
https://docs.google.com/document/d/1TqhWG2wCz5pKvTLfhFGPINz6VVmCOlBgQc6vv2Ua4nM/edit#heading=h.fk37uvb8ev6v

# How should this be tested?

1. Follow instructions from [README](https://github.com/harvard-lts/drs-translation-service/tree/ETD-147#testing) for pytest testing
2. Follow instructions from [README](https://github.com/harvard-lts/drs-translation-service/tree/ETD-147#invoke-dlq-taskpy-add-message-that-will-be-rejected-to-the-queue) for invoke-dlq-task
3. (Already done) Deploy to dev and push a batch through the DAIS pipeline successfully

# Test coverage
Yes/No: Are changes in this pull-request covered by:
- unit tests? yes
- integration tests? no

# Interested parties
@awoods 
