### PR TITLE
Fix for missing file role for Opaque objects

### DIFF
--- a/app/batch_builder_service/etd_batch_builder_service.py
+++ b/app/batch_builder_service/etd_batch_builder_service.py
@@ -86,12 +86,16 @@ class ETDBatchBuilderService(BatchBuilderService):
         '''Builds the -dirprop command'''
         dirs = os.listdir(object_path)
         for dir in dirs:
-            if os.path.isdir(os.path.join(object_path, dir)):
+            dir_path = os.path.join(object_path, dir)
+            if os.path.isdir(dir_path):
                 filerole = FILE_ROLE_ARCHIVAL_MASTER
                 if role == ROLE_DOCUMENTATION or role == ROLE_LICENSE:
                     filerole = role
+                self.logger.debug("File role: {} for {}".format(filerole,
+                                                                dir_path))
                 overrides = "filerole={};".format(filerole)
-                return "{}::{}::{}".format(os.path.basename(object_path), dir, overrides)
+                return "{}::{}::{}".format(os.path.basename(object_path),
+                                           dir, overrides)
         return ""
     
     def __determine_role(self, object_name):

--- a/app/batch_builder_service/etd_batch_builder_service.py
+++ b/app/batch_builder_service/etd_batch_builder_service.py
@@ -85,6 +85,7 @@ class ETDBatchBuilderService(BatchBuilderService):
     def _build_dirprop_override_command(self, object_path, role):
         '''Builds the -dirprop command'''
         dirs = os.listdir(object_path)
+        overrides = ""
         for dir in dirs:
             dir_path = os.path.join(object_path, dir)
             if os.path.isdir(dir_path):
@@ -93,11 +94,13 @@ class ETDBatchBuilderService(BatchBuilderService):
                     filerole = role
                 self.logger.debug("File role: {} for {}".format(filerole,
                                                                 dir_path))
-                overrides = "filerole={};".format(filerole)
-                return "{}::{}::{}".format(os.path.basename(object_path),
-                                           dir, overrides)
-        return ""
-    
+                dir_override = "filerole={};".format(filerole)
+                overrides += "{}::{}::{}".format(
+                    os.path.basename(object_path),
+                                     dir, dir_override)
+        self.logger.debug("File Overrides: {}".format(overrides))
+        return overrides
+
     def __determine_role(self, object_name):
         '''The OSN will have been formatted before the DAIS pipeline so
         the role will be extracted from the OSN name.'''


### PR DESCRIPTION
**Opaque file role is now ARCHIVAL_MASTER as required.*
* * *

**JIRA Issue**: https://at-harvard.atlassian.net/browse/ETD-321

# How should this be tested?
NOTE: This was already done manually but to verify on your own, you will have to wait until DRS dev/qa indexing is fixed.

1. Submit a sample batch with opaque into dev using the integration test: https://ltsds-cloud-dev-1.lib.harvard.edu:10610/etd_with_opaque_test.  
2. Verify that the object has the correct relationships.  


# Test coverage
Yes/No: Are changes in this pull-request covered by:
- unit tests? no
- integration tests? no
